### PR TITLE
feat: add animated gradient landing visuals

### DIFF
--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -4,7 +4,7 @@ title: Home
 slug: index
 metaTitle: "Jannik Adam – Freiberuflicher SAP Berater & Entwickler"
 metaDescription: "Freiberufliche SAP-Beratung und -Entwicklung. Ich helfe Unternehmen, ihre Prozesse zu optimieren und moderne Anwendungen aufzubauen."
-colors: colors-b
+colors: colors-c
 backgroundImage:
   type: BackgroundImage
   url: /images/bg1.jpg
@@ -14,7 +14,7 @@ backgroundImage:
   opacity: 75
 sections:
   - type: HeroSection
-    colors: colors-b
+    colors: colors-c
     backgroundSize: full
     title: Cloudbuds – Freiberuflicher SAP Berater & Entwickler
     subtitle: Maßgeschneiderte SAP-Beratung und Entwicklung für deine Geschäftsprozesse
@@ -39,8 +39,9 @@ sections:
           - pr-4
         flexDirection: row-reverse
         textAlign: left
+        backgroundImage: bg-gradient-to-br from-blue-700 via-blue-600 to-indigo-700
   - type: ContactSection
-    colors: colors-b
+    colors: colors-d
     backgroundSize: full
     title: Got an interesting project?
     form:
@@ -96,6 +97,7 @@ sections:
           - pl-4
         flexDirection: row
         textAlign: left
+        backgroundImage: bg-gradient-to-r from-indigo-700 via-indigo-600 to-blue-600
   - type: CtaSection
     text: By submitting this form I accept the [Privacy Policy](/privacy).
     styles:

--- a/src/components/sections/ContactSection/index.tsx
+++ b/src/components/sections/ContactSection/index.tsx
@@ -11,7 +11,7 @@ export default function ContactSection(props) {
     const sectionAlign = styles.self?.textAlign ?? 'left';
     return (
         <Section elementId={elementId} colors={colors} backgroundSize={backgroundSize} styles={styles.self}>
-            <div className={classNames('flex gap-8', mapFlexDirectionStyles(styles.self?.flexDirection ?? 'row'))}>
+            <div className={classNames('flex gap-8 animate-slide-in', mapFlexDirectionStyles(styles.self?.flexDirection ?? 'row'))}>
                 <div className="flex-1 w-full">
                     {title && (
                         <h2 className={classNames('text-4xl sm:text-5xl', mapStyles({ textAlign: sectionAlign }))}>

--- a/src/components/sections/HeroSection/index.tsx
+++ b/src/components/sections/HeroSection/index.tsx
@@ -19,7 +19,7 @@ export default function Component(props: HeroSection) {
     const sectionAlign = styles.self?.textAlign ?? 'left';
     return (
         <Section elementId={elementId} colors={colors} backgroundSize={backgroundSize} styles={styles.self}>
-            <div className={classNames('flex gap-8', mapFlexDirectionStyles(sectionFlexDirection))}>
+            <div className={classNames('flex gap-8 animate-slide-in', mapFlexDirectionStyles(sectionFlexDirection))}>
                 <div className={classNames('flex-1 w-full', mapStyles({ textAlign: sectionAlign }))}>
                     {title && (
                         <AnnotatedField path=".title">

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -159,3 +159,18 @@ layer(base);
         background-size: 100% 100%;
     }
 }
+
+@keyframes slide-in {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@utility animate-slide-in {
+    animation: slide-in 0.75s ease-out both;
+}


### PR DESCRIPTION
## Summary
- switch landing and hero sections to vibrant primary/secondary themes with gradient backgrounds
- add slide-in animation utility and apply to hero and contact sections
- introduce custom CSS keyframes for smooth content entrance

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6898e4237d7483208cd320b5d43cb469