### PR TITLE
refactor: remove isMounted check

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -1,16 +1,13 @@
 import { generateGlobalCssVariables } from '@/utils/theme-style-utils';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import '../css/main.css';
 
 export default function MyApp({ Component, pageProps }) {
     const { global, ...page } = pageProps;
     const { theme } = global || {};
-    const [isMounted, setIsMounted] = useState(false);
-
     const cssVars = generateGlobalCssVariables(theme);
 
     useEffect(() => {
-        setIsMounted(true);
         document.body.setAttribute('data-theme', page.colors || 'colors-a');
     }, [page.colors]);
 
@@ -21,7 +18,7 @@ export default function MyApp({ Component, pageProps }) {
                     ${cssVars}
                 }
             `}</style>
-            {isMounted ? <Component {...pageProps} /> : null}
+            <Component {...pageProps} />
         </>
     );
 }


### PR DESCRIPTION
## Summary
- simplify MyApp component rendering by dropping client-only `isMounted` gating
- useEffect now solely sets the body's `data-theme`

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_6898e75325448320907b614ab72bedec