### PR TITLE
Use fill for ImageBlock and enforce alt text

### DIFF
--- a/src/components/molecules/ImageBlock/index.tsx
+++ b/src/components/molecules/ImageBlock/index.tsx
@@ -2,25 +2,26 @@ import Image from 'next/image';
 import { Annotated } from '@/components/Annotated';
 
 export default function ImageBlock(props) {
-    const { elementId, className, url, altText = '' } = props;
+    const { elementId, className, url, altText, caption } = props;
     if (!url) {
         return null;
     }
 
+    const alt = altText || caption || 'Image';
+
     return (
         <Annotated content={props}>
-            <Image
-                id={elementId || undefined}
-                className={className}
-                src={url}
-                alt={altText}
-                width={0}
-                height={0}
-                sizes="100vw"
-                style={{ width: '100%', height: 'auto' }}
-                loading="lazy"
-                decoding="async"
-            />
+            <div id={elementId || undefined} className="relative w-full h-full">
+                <Image
+                    className={className}
+                    src={url}
+                    alt={alt}
+                    fill
+                    sizes="100vw"
+                    loading="lazy"
+                    decoding="async"
+                />
+            </div>
         </Annotated>
     );
 }

--- a/src/components/molecules/__tests__/ImageBlock.test.tsx
+++ b/src/components/molecules/__tests__/ImageBlock.test.tsx
@@ -1,7 +1,8 @@
 import { render } from '@testing-library/react';
 
 // Mock next/image to render img element
-jest.mock('next/image', () => (props) => <img {...props} />);
+// Remove Next.js specific props like `fill` to avoid React warnings
+jest.mock('next/image', () => ({ fill, ...rest }) => <img {...rest} />);
 
 import ImageBlock from '../ImageBlock';
 
@@ -9,6 +10,16 @@ describe('ImageBlock', () => {
     it('renders image when url provided', () => {
         const { getByAltText } = render(<ImageBlock url="/test.jpg" altText="test" />);
         expect(getByAltText('test')).toBeInTheDocument();
+    });
+
+    it('falls back to caption when altText missing', () => {
+        const { getByAltText } = render(<ImageBlock url="/test.jpg" caption="caption" />);
+        expect(getByAltText('caption')).toBeInTheDocument();
+    });
+
+    it('uses default alt text when none provided', () => {
+        const { getByAltText } = render(<ImageBlock url="/test.jpg" />);
+        expect(getByAltText('Image')).toBeInTheDocument();
     });
 
     it('returns null when no url', () => {


### PR DESCRIPTION
## Summary
- Use `next/image` fill mode inside a positioned container for ImageBlock instead of width/height workaround
- Always provide meaningful `alt` text, falling back to caption or generic label
- Extend ImageBlock tests and mock to cover new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e76e973483209936837854a798ba