### PR TITLE
chore: load fonts via document links

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Azeret+Mono:ital,wght@0,400;0,500;1,400;1,500&family=DM+Mono:ital,wght@0,400;0,500;1,400;1,500&display=swap')
 layer(base);
 
 @import 'tailwindcss';

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,6 +5,12 @@ export default function Document() {
     <Html lang="de">
       <Head>
         <script async src="https://cloudbuds.de/proxy.js"></script>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Azeret+Mono:ital,wght@0,400;0,500;1,400;1,500&family=DM+Mono:ital,wght@0,400;0,500;1,400;1,500&display=swap"
+          rel="stylesheet"
+        />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Summary
- remove Google Fonts `@import` from Tailwind CSS
- load DM Mono & Azeret Mono via `<link>` tags with `display=swap`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6898e779b1508320af8f44206bc55cfb