### PR TITLE
Enable robots.txt generation via next-sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,5 +1,5 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_SITE_URL || 'https://cloudbuds.de',
-  generateRobotsTxt: false,
+  generateRobotsTxt: true,
 };

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: /sitemap.xml


### PR DESCRIPTION
## Summary
- enable robots.txt generation in next-sitemap config
- remove manually maintained robots.txt from `public`

## Testing
- `npm test`
- `npm run build` *(fails: Unknown word in src/css/main.css)*
- `npm run postbuild`

------
https://chatgpt.com/codex/tasks/task_e_6898eb21e394832093af3d40bf680987